### PR TITLE
Fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ A collection of Little Snitch rules
 
 ## Collections:
 
-[Dropbox](Rules/Dropbox.lsrules?raw=true "Dropbox")
+[Dropbox](Rules/Dropbox.lsrules?raw=true "Dropbox"): A list of rules that allow Dropbox to access necessary online resources

--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 A collection of Little Snitch rules
 
 ## Collections:
-* [Dropbox](x-littlesnitch:subscribe-rules?url=https%3A%2F%2Fraw.githubusercontent.com%2Fandrewdmontgomery%2Flittlesnitch%2Fmaster%2FDropbox.lsrules): A list of rules that allow Dropbox to access necessary online resources
+
+[Dropbox](Rules/Dropbox.lsrules?raw=true "Dropbox")


### PR DESCRIPTION
Github doesn't seem to support links with non-http URI's.  This PR fixes that, and uses relative links instead.